### PR TITLE
fixing syntax errors and updating monadic functions to new names

### DIFF
--- a/grammars/abstractSyntax/Expr.sv
+++ b/grammars/abstractSyntax/Expr.sv
@@ -3,7 +3,7 @@ grammar grammars:abstractSyntax;
 
 synthesized attribute pp::String;
 
-Implicit synthesized attribute type::Maybe<Type>;
+implicit synthesized attribute type::Maybe<Type>;
 
 
 nonterminal Expr with
@@ -35,7 +35,7 @@ top::Expr ::= b::Bindings e::Expr
 
 
 --To make sure bindings are well-typed, where we don't get a type out, we need a Boolean
-Implicit synthesized attribute typeOK::Maybe<Boolean>;
+implicit synthesized attribute typeOK::Maybe<Boolean>;
 
 nonterminal Bindings with
    pp, gamma, gamma_out, subst, subst_out, knownConstructors, typeOK, knownTypes;
@@ -104,8 +104,8 @@ top::Expr ::= b::RecBindings e::Expr
 
 
 --we need rec substs so gamma_out doesn't depend on the regular subst, which depends on e.type
-Implicit inherited attribute recSubst::Maybe<[Pair<String Type>]>;
-Implicit synthesized attribute recSubst_out::Maybe<[Pair<String Type>]>;
+implicit inherited attribute recSubst::Maybe<[Pair<String Type>]>;
+implicit synthesized attribute recSubst_out::Maybe<[Pair<String Type>]>;
 
 nonterminal RecBindings with
    pp, gamma, gamma_out, subst, subst_out, knownConstructors, typeOK, knownTypes, recSubst, recSubst_out;
@@ -275,7 +275,7 @@ top::Expr ::= tc::TupleContents
 }
 
 
-Implicit synthesized attribute tc_type::Maybe<TupleTyBuild>;
+implicit synthesized attribute tc_type::Maybe<TupleTyBuild>;
 
 
 nonterminal TupleContents with
@@ -1512,7 +1512,7 @@ top::Expr ::= e::Expr clauses::SimpleMatching
 }
 
 
-Implicit synthesized attribute matchType::Maybe<Type>;
+implicit synthesized attribute matchType::Maybe<Type>;
 
 nonterminal SimpleMatching with
    pp, knownConstructors, gamma, subst, subst_out, type, matchType, knownTypes;
@@ -1580,7 +1580,7 @@ top::Expr ::= clauses::MultipleMatching
 }
 
 
-Implicit synthesized attribute ptyList::Maybe<[Type]>;
+implicit synthesized attribute ptyList::Maybe<[Type]>;
 
 nonterminal PatternList with
    pp, knownConstructors, gamma_out, ptyList, subst, subst_out, knownTypes;

--- a/grammars/abstractSyntax/Pattern.sv
+++ b/grammars/abstractSyntax/Pattern.sv
@@ -331,7 +331,7 @@ top::Pattern ::= contents::TuplePatternContents
 }
 
 
-Implicit synthesized attribute ttb_type::Maybe<TupleTyBuild>;
+implicit synthesized attribute ttb_type::Maybe<TupleTyBuild>;
 
 nonterminal TuplePatternContents with
    pp, gamma, gamma_out, subst, subst_out, ttb_type, knownConstructors, knownTypes;

--- a/grammars/abstractSyntax/Root.sv
+++ b/grammars/abstractSyntax/Root.sv
@@ -8,19 +8,19 @@ type TyCtxType = [Pair<String Type>];
 
 
 --A list of known atomic types
-Restricted inherited attribute knownTypes::[Pair<String ExtantType>];
+restricted inherited attribute knownTypes::[Pair<String ExtantType>];
 
 --A list of known names, including constructors
 --This needs to be implicit because the type attribute flows into it
-Implicit inherited attribute gamma::Maybe<TyCtxType>;
+implicit inherited attribute gamma::Maybe<TyCtxType>;
 
 --A list of type substitutions for type variables
 --Why is this an implicit Maybe?  This allows us to use the implicit
 --   type to decide what this will be.
-Implicit inherited attribute subst::Maybe<[Pair<String Type>]>;
+implicit inherited attribute subst::Maybe<[Pair<String Type>]>;
 
 --A list of constructors and their types
-Restricted inherited attribute knownConstructors::[Pair<String Type>];
+restricted inherited attribute knownConstructors::[Pair<String Type>];
 
 
 --find out whether a given type is real and how many parameters it has
@@ -59,14 +59,14 @@ Type ::= name::String gamma::[Pair<String Type>] d::Type
 
 
 --the updated contexts after a declaration
-Implicit synthesized attribute gamma_out::Maybe<TyCtxType>;
-Restricted synthesized attribute knownTypes_out::[Pair<String ExtantType>];
-Implicit synthesized attribute subst_out::Maybe<[Pair<String Type>]>;
-Restricted synthesized attribute knownConstructors_out::[Pair<String Type>];
+implicit synthesized attribute gamma_out::Maybe<TyCtxType>;
+restricted synthesized attribute knownTypes_out::[Pair<String ExtantType>];
+implicit synthesized attribute subst_out::Maybe<[Pair<String Type>]>;
+restricted synthesized attribute knownConstructors_out::[Pair<String Type>];
 
 
 
-Restricted synthesized attribute defOK::Boolean;
+restricted synthesized attribute defOK::Boolean;
 
 
 nonterminal ExceptionDef with

--- a/grammars/abstractSyntax/Type.sv
+++ b/grammars/abstractSyntax/Type.sv
@@ -2,11 +2,11 @@ grammar grammars:abstractSyntax;
 
 
 --whether the types are valid (nobody is throwing in an undefined type or using a type wrong)
-Restricted synthesized attribute validType::Boolean;
+restricted synthesized attribute validType::Boolean;
 --variables that occur in a type
-Restricted synthesized attribute freeTyVars::[String];
+restricted synthesized attribute freeTyVars::[String];
 --whether the type constructors are valid (new variables can be introduced)
-Restricted synthesized attribute validNewVarType::Boolean;
+restricted synthesized attribute validNewVarType::Boolean;
 
 nonterminal Type with pp, knownTypes, knownTyVars, validType, freeTyVars, validNewVarType;
 
@@ -504,11 +504,11 @@ Type ::= l::[Type] result::Type
 
 --types known before the current definition set
 --this is for determining whether a type has been defined before
-Restricted inherited attribute priorTypes::[Pair<String ExtantType>];
+restricted inherited attribute priorTypes::[Pair<String ExtantType>];
 --The name of the type being defined
-Restricted synthesized attribute name::String;
+restricted synthesized attribute name::String;
 
-Restricted inherited attribute knownTyVars::[String];
+restricted inherited attribute knownTyVars::[String];
 
 nonterminal TypeDef with
    pp, knownTypes, knownTypes_out, knownConstructors, knownConstructors_out, defOK, priorTypes, name;
@@ -538,9 +538,9 @@ top::TypeDef ::= params::TypeParams name::String constructors::Constructors
 }
 
 
-Restricted synthesized attribute len::Integer;
-Restricted synthesized attribute tyParams::[Type];
-Restricted synthesized attribute names::[String];
+restricted synthesized attribute len::Integer;
+restricted synthesized attribute tyParams::[Type];
+restricted synthesized attribute names::[String];
 
 nonterminal TypeParams with pp, len, tyParams, names;
 
@@ -570,7 +570,7 @@ top::TypeParams ::=
 
 
 --The type the constructors are going to be building.
-Restricted inherited attribute buildingType::Type;
+restricted inherited attribute buildingType::Type;
 
 nonterminal Constructors with
    pp, buildingType, gamma, knownTypes, knownTyVars, knownConstructors, knownConstructors_out, defOK;
@@ -750,7 +750,7 @@ top::TypeDefs ::=
 }
 
 
-Restricted synthesized attribute tyNames::[String];
+restricted synthesized attribute tyNames::[String];
 
 nonterminal TypeDefinition with
    pp, knownTypes, knownTypes_out, knownConstructors, knownConstructors_out, defOK, tyNames;

--- a/grammars/concreteSyntax/Concrete.sv
+++ b/grammars/concreteSyntax/Concrete.sv
@@ -228,7 +228,7 @@ concrete productions top::Pattern_Sub5
 | '(' p::Pattern_c ')'
   { top.ast = p.ast; }
 | i::IntegerLiteral_t
-  { top.ast = intPattern(toInt(i.lexeme)); }
+  { top.ast = intPattern(toInteger(i.lexeme)); }
 | f::FloatLiteral_Dec_t
   { top.ast = floatPattern(toFloat(f.lexeme)); }
 | f::FloatLiteral_Exp_t

--- a/grammars/concreteSyntax/ConcreteExpressions.sv
+++ b/grammars/concreteSyntax/ConcreteExpressions.sv
@@ -167,7 +167,7 @@ concrete productions top::BasicExpr_c
 | id::Identifier_t
   { top.ast = var(id.lexeme); }
 | i::IntegerLiteral_t
-  { top.ast = intConst(toInt(i.lexeme)); }
+  { top.ast = intConst(toInteger(i.lexeme)); }
 | f::FloatLiteral_Exp_t
   { top.ast = floatConst(toFloat(f.lexeme)); }
 | f::FloatLiteral_Dec_t

--- a/grammars/driver/Main.sv
+++ b/grammars/driver/Main.sv
@@ -12,25 +12,25 @@ parser hostparse::Root_c
 }
 
 function main
-IOVal<Integer> ::= largs::[String] ioin::IO
+IOVal<Integer> ::= largs::[String] ioin::IOToken
 {
   local filename::String = head(largs);
-  local fileExists::IOVal<Boolean> = isFile(filename, ioin);
-  local text::IOVal<String> = readFile(filename, fileExists.io);
+  local fileExists::IOVal<Boolean> = isFileT(filename, ioin);
+  local text::IOVal<String> = readFileT(filename, fileExists.io);
   local result::ParseResult<Root_c> = hostparse(text.iovalue, filename);
 
   local r_cst::Root_c = result.parseTree;
   local attribute r_ast::Root = r_cst.ast;
 
-  local print_success::IO = print(r_ast.output ++ "\n", text.io);
+  local print_success::IOToken = printT(r_ast.output ++ "\n", text.io);
 
   return if null(largs)
-         then ioval(print("Filename not provided.\n", ioin), 1)
+         then ioval(printT("Filename not provided.\n", ioin), 1)
          else if !fileExists.iovalue
-              then ioval(print("File does not exist.\n",
+              then ioval(printT("File does not exist.\n",
                                fileExists.io), 1)
               else if !result.parseSuccess
-                   then ioval(print("Parse failed.\n" ++
+                   then ioval(printT("Parse failed.\n" ++
                               result.parseErrors ++ "\n", text.io), 1)
                    else ioval(print_success, 0);
 }


### PR DESCRIPTION
The code here seems to be using an outdated version of the concrete syntax. By replacing capitalized modifiers, e.g. `Implicit`, with their uncapitalized versions, e.g. `implicit`, I could fix the syntax errors.

I also fixed the monadic code in the driver to use the new names for the old-style of code that is there.

There are still semantic errors that I am not sure how to fix.